### PR TITLE
Fix keyword to check being/end characters

### DIFF
--- a/storyscript.iro
+++ b/storyscript.iro
@@ -232,14 +232,14 @@ varattr : context {
 
 keyword : context {
    : pattern {
-      regex          \= (break|as|catch|returns?|continue|else|finally|if|then|try|when|while|foreach|and|or)
+      regex          \= ((?!\W)(break|as|catch|returns?|continue|else|finally|if|then|try|when|while|foreach|and|or)(\s|$))
       styles []       = .keyword;
    }
 }
 
 function : context {
    : inline_push {
-      regex          \= (function)
+      regex          \= ((?!\W)(function)(?=\s))
       styles []       = .function;
       default_style   = .function
       : pop {
@@ -265,7 +265,7 @@ illegal : context {
 
 type : context {
    : pattern {
-      regex          \= $${__TYPE}
+      regex          \= ((?!\W)$${__TYPE}((?=\W)|$))
       styles []       = .type;
    }
 }
@@ -379,7 +379,7 @@ null : context {
 
 boolean : context {
    : pattern {
-      regex          \= (true|false)
+      regex          \= ((?!\W)(true|false)(?=\s))
       styles []      = .boolean;
    }
 }


### PR DESCRIPTION
Before
<img width="112" alt="Screen Shot 2019-04-08 at 12 09 54" src="https://user-images.githubusercontent.com/2041757/55716434-428f6a00-59f7-11e9-8bdb-370bde2a8007.png">

After
<img width="101" alt="Screen Shot 2019-04-08 at 12 09 59" src="https://user-images.githubusercontent.com/2041757/55716437-44592d80-59f7-11e9-9815-88b20eb61a1f.png">
