### PR TITLE
update some missing types and keywords

### DIFF
--- a/dist/ace/storyscript.js
+++ b/dist/ace/storyscript.js
@@ -22,7 +22,7 @@ define(function(require, exports, module) {
       },
       {
          "token" : "keyword.control.flow",
-         "regex" : "((?!\\W)(break|as|catch|returns?|continue|is|not|else|finally|if|then|try|when|while|foreach|and|or)(\\s|$))"
+         "regex" : "((?!\\W)(break|as|to|catch|throw|returns?|continue|is|not|else|finally|if|then|try|when|while|foreach|and|or)(\\s|$))"
       },
       {
          "token" : "keyword.operator.assignment",
@@ -69,7 +69,7 @@ define(function(require, exports, module) {
       },
       {
          "token" : "support.type",
-         "regex" : "((?!\\W)(int|string|boolean|map|list|object)((?=\\W)|$))"
+         "regex" : "((?!\\W)(int|float|string|boolean|Map|List|object|regex|any|time)((?=\\W)|$))"
       },
       {
          "token" : "support.constant",
@@ -147,12 +147,12 @@ define(function(require, exports, module) {
    "keytype__1" : [
       {
          "token" : "variable.parameter.function",
-         "regex" : "((?!\\s*:\\s*(int|string|boolean|map|list|object)))",
+         "regex" : "((?!\\s*:\\s*(int|float|string|boolean|Map|List|object|regex|any|time)))",
          "next" : "pop"
       },
       {
          "token" : "support.type",
-         "regex" : "((?!\\W)(int|string|boolean|map|list|object)((?=\\W)|$))"
+         "regex" : "((?!\\W)(int|float|string|boolean|Map|List|object|regex|any|time)((?=\\W)|$))"
       },
       {
          "token" : "constant.character.punctuation",
@@ -213,7 +213,7 @@ define(function(require, exports, module) {
       },
       {
          "token" : "support.type",
-         "regex" : "((?!\\W)(int|string|boolean|map|list|object)((?=\\W)|$))"
+         "regex" : "((?!\\W)(int|float|string|boolean|Map|List|object|regex|any|time)((?=\\W)|$))"
       },
       {
          "token" : "support.constant",
@@ -323,7 +323,7 @@ define(function(require, exports, module) {
       },
       {
          "token" : "support.type",
-         "regex" : "((?!\\W)(int|string|boolean|map|list|object)((?=\\W)|$))"
+         "regex" : "((?!\\W)(int|float|string|boolean|Map|List|object|regex|any|time)((?=\\W)|$))"
       },
       {
          "token" : "support.constant",
@@ -435,7 +435,7 @@ define(function(require, exports, module) {
       },
       {
          "token" : "support.type",
-         "regex" : "((?!\\W)(int|string|boolean|map|list|object)((?=\\W)|$))"
+         "regex" : "((?!\\W)(int|float|string|boolean|Map|List|object|regex|any|time)((?=\\W)|$))"
       },
       {
          "token" : "support.constant",
@@ -537,7 +537,7 @@ define(function(require, exports, module) {
       },
       {
          "token" : "support.type",
-         "regex" : "((?!\\W)(int|string|boolean|map|list|object)((?=\\W)|$))"
+         "regex" : "((?!\\W)(int|float|string|boolean|Map|List|object|regex|any|time)((?=\\W)|$))"
       },
       {
          "token" : "support.constant",

--- a/storyscript.iro
+++ b/storyscript.iro
@@ -28,7 +28,7 @@ textmate_uuid          = DB4E14AE-D10C-4B28-A55E-7C895B402701
 ## Constants
 ################################################################
 
-__TYPE \= (int|string|boolean|map|list|object)
+__TYPE \= (int|float|string|boolean|Map|List|object|regex|any|time)
 __WORD \= [\w_]+
 
 ################################################################

--- a/storyscript.iro
+++ b/storyscript.iro
@@ -239,7 +239,7 @@ varattr : context {
 
 keyword : context {
    : pattern {
-      regex          \= ((?!\W)(break|as|catch|returns?|continue|is|not|else|finally|if|then|try|when|while|foreach|and|or)(\s|$))
+      regex          \= ((?!\W)(break|as|to|catch|throw|returns?|continue|is|not|else|finally|if|then|try|when|while|foreach|and|or)(\s|$))
       styles []       = .keyword;
    }
 }

--- a/syntax.story
+++ b/syntax.story
@@ -89,7 +89,7 @@ Long {strings}
 [1, 1.2, -1]
 
 # Types
-int string function null boolean map list object
+int string function null boolean object Map List regex any float
 
 # Keyword
 and or

--- a/syntax.story
+++ b/syntax.story
@@ -93,8 +93,8 @@ int string function null boolean object Map List regex any float
 
 # Keyword
 and or
-when return returns as foreach
-while if else try catch finally
+when return returns as to foreach
+while if else try catch throw finally
 break continue
 
 # Puncuation


### PR DESCRIPTION
chore(Syntax): add missing types and remove which are no longer one.
chore(Syntax): add `throw` and `to` keywords.
chore(Ace): update Ace syntax distribution with latest changes.

Fixes: #1
Fixes: #10